### PR TITLE
fix: Update .env to avoid `RangeError: Maximum call stack size exceeded`

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DATABASE_URL= ${DATABASE_URL}
+DATABASE_URL="your-database-connection-string-goes-here"


### PR DESCRIPTION
Without this change, if you clone and run `npm run build`

It will result in this cryptic error:
```
> cockroachdb-typescript@0.1.0 build /workspaces/cockroachdb-typescript
> react-scripts build

/workspaces/cockroachdb-typescript/node_modules/dotenv-expand/lib/main.js:11
      var parts = /(.?)\${?([a-zA-Z0-9_]+)?}?/g.exec(match)
                                                ^

RangeError: Maximum call stack size exceeded
    at RegExp.exec (<anonymous>)
    at /workspaces/cockroachdb-typescript/node_modules/dotenv-expand/lib/main.js:11:49
    at Array.reduce (<anonymous>)
    at interpolate (/workspaces/cockroachdb-typescript/node_modules/dotenv-expand/lib/main.js:10:20)
    at /workspaces/cockroachdb-typescript/node_modules/dotenv-expand/lib/main.js:26:17
    at Array.reduce (<anonymous>)
    at interpolate (/workspaces/cockroachdb-typescript/node_modules/dotenv-expand/lib/main.js:10:20)
    at /workspaces/cockroachdb-typescript/node_modules/dotenv-expand/lib/main.js:26:17
    at Array.reduce (<anonymous>)
    at interpolate (/workspaces/cockroachdb-typescript/node_modules/dotenv-expand/lib/main.js:10:20)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! cockroachdb-typescript@0.1.0 build: `react-scripts build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the cockroachdb-typescript@0.1.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

So changing the value here avoids that.